### PR TITLE
Results from Chrome 86.0.4240.193 / Mac OS 10.15.7 / Collector v0.5.9-dev

### DIFF
--- a/0.5.9-dev-chrome-86.0.4240.193-mac-os-10.15.7-6721404a28.json
+++ b/0.5.9-dev-chrome-86.0.4240.193-mac-os-10.15.7-6721404a28.json
@@ -1,0 +1,72 @@
+{
+  "__version": "0.5.9",
+  "results": {
+    "http://localhost:8080/tests/api/AbortController": [
+      {
+        "info": {
+          "code": "\"AbortController\" in self",
+          "exposure": "Window"
+        },
+        "name": "api.AbortController",
+        "result": true
+      },
+      {
+        "info": {
+          "code": "\"abort\" in AbortController.prototype",
+          "exposure": "Window"
+        },
+        "name": "api.AbortController.abort",
+        "result": true
+      },
+      {
+        "info": {
+          "code": "bcd.testConstructor(\"AbortController\");",
+          "exposure": "Window"
+        },
+        "name": "api.AbortController.AbortController",
+        "result": true
+      },
+      {
+        "info": {
+          "code": "\"signal\" in AbortController.prototype",
+          "exposure": "Window"
+        },
+        "name": "api.AbortController.signal",
+        "result": true
+      },
+      {
+        "info": {
+          "code": "\"AbortController\" in self",
+          "exposure": "Worker"
+        },
+        "name": "api.AbortController",
+        "result": true
+      },
+      {
+        "info": {
+          "code": "\"abort\" in AbortController.prototype",
+          "exposure": "Worker"
+        },
+        "name": "api.AbortController.abort",
+        "result": true
+      },
+      {
+        "info": {
+          "code": "bcd.testConstructor(\"AbortController\");",
+          "exposure": "Worker"
+        },
+        "name": "api.AbortController.AbortController",
+        "result": true
+      },
+      {
+        "info": {
+          "code": "\"signal\" in AbortController.prototype",
+          "exposure": "Worker"
+        },
+        "name": "api.AbortController.signal",
+        "result": true
+      }
+    ]
+  },
+  "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.193 Safari/537.36"
+}


### PR DESCRIPTION
json: {
  "__version": "0.5.9",
  "results": {
    "http://localhost:8080/tests/api/AbortController": [
      {
        "info": {
          "code": "\"AbortController\" in self",
          "exposure": "Window"
        },
        "name": "api.AbortController",
        "result": true
      },
      {
        "info": {
          "code": "\"abort\" in AbortController.prototype",
          "exposure": "Window"
        },
        "name": "api.AbortController.abort",
        "result": true
      },
      {
        "info": {
          "code": "bcd.testConstructor(\"AbortController\");",
          "exposure": "Window"
        },
        "name": "api.AbortController.AbortController",
        "result": true
      },
      {
        "info": {
          "code": "\"signal\" in AbortController.prototype",
          "exposure": "Window"
        },
        "name": "api.AbortController.signal",
        "result": true
      },
      {
        "info": {
          "code": "\"AbortController\" in self",
          "exposure": "Worker"
        },
        "name": "api.AbortController",
        "result": true
      },
      {
        "info": {
          "code": "\"abort\" in AbortController.prototype",
          "exposure": "Worker"
        },
        "name": "api.AbortController.abort",
        "result": true
      },
      {
        "info": {
          "code": "bcd.testConstructor(\"AbortController\");",
          "exposure": "Worker"
        },
        "name": "api.AbortController.AbortController",
        "result": true
      },
      {
        "info": {
          "code": "\"signal\" in AbortController.prototype",
          "exposure": "Worker"
        },
        "name": "api.AbortController.signal",
        "result": true
      }
    ]
  },
  "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.193 Safari/537.36"
}

buffer: {
  "__version": "0.5.9",
  "results": {
    "http://localhost:8080/tests/api/AbortController": [
      {
        "info": {
          "code": "\"AbortController\" in self",
          "exposure": "Window"
        },
        "name": "api.AbortController",
        "result": true
      },
      {
        "info": {
          "code": "\"abort\" in AbortController.prototype",
          "exposure": "Window"
        },
        "name": "api.AbortController.abort",
        "result": true
      },
      {
        "info": {
          "code": "bcd.testConstructor(\"AbortController\");",
          "exposure": "Window"
        },
        "name": "api.AbortController.AbortController",
        "result": true
      },
      {
        "info": {
          "code": "\"signal\" in AbortController.prototype",
          "exposure": "Window"
        },
        "name": "api.AbortController.signal",
        "result": true
      },
      {
        "info": {
          "code": "\"AbortController\" in self",
          "exposure": "Worker"
        },
        "name": "api.AbortController",
        "result": true
      },
      {
        "info": {
          "code": "\"abort\" in AbortController.prototype",
          "exposure": "Worker"
        },
        "name": "api.AbortController.abort",
        "result": true
      },
      {
        "info": {
          "code": "bcd.testConstructor(\"AbortController\");",
          "exposure": "Worker"
        },
        "name": "api.AbortController.AbortController",
        "result": true
      },
      {
        "info": {
          "code": "\"signal\" in AbortController.prototype",
          "exposure": "Worker"
        },
        "name": "api.AbortController.signal",
        "result": true
      }
    ]
  },
  "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.193 Safari/537.36"
}

hash: [object Object]
digest: 6721404a28
ua: [object Object]
browser: Chrome 86.0.4240.193
os: Mac OS 10.15.7
desc: Chrome 86.0.4240.193 / Mac OS 10.15.7
title: Results from Chrome 86.0.4240.193 / Mac OS 10.15.7 / Collector v0.5.9-dev
slug: chrome-86.0.4240.193-mac-os-10.15.7
filename: 0.5.9-dev-chrome-86.0.4240.193-mac-os-10.15.7-6721404a28.json
branch: collector/0.5.9-dev-chrome-86.0.4240.193-mac-os-10.15.7-6721404a28

**WARNING:** this PR was created from a development/staging version!