### PR TITLE
Results from Safari 14 / Mac OS 10.15.7 / Collector v1.3.0

### DIFF
--- a/1.3.0-safari-14.0.2-mac-os-10.15.7-24e10e3838.json
+++ b/1.3.0-safari-14.0.2-mac-os-10.15.7-24e10e3838.json
@@ -1,0 +1,1 @@
+{"__version":"1.3.0","results":{"https://mdn-bcd-collector.appspot.com/tests/api/TrackEvent/track":[{"info":{"code":"\"track\" in TrackEvent.prototype","exposure":"Window"},"name":"api.TrackEvent.track","result":true}]},"userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0.2 Safari/605.1.15"}


### PR DESCRIPTION
User Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0.2 Safari/605.1.15
Browser: Safari 14 (on Mac OS 10.15.7) 
Hash Digest: 24e10e3838
