### PR TITLE
Results from Safari 14 / Mac OS 10.15.6 / Collector v3.0.1

### DIFF
--- a/3.0.1-safari-14.0.3-mac-os-10.15.6-5de2f9eeda.json
+++ b/3.0.1-safari-14.0.3-mac-os-10.15.6-5de2f9eeda.json
@@ -1,0 +1,1 @@
+{"__version":"3.0.1","results":{},"userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0.3 Safari/605.1.15"}


### PR DESCRIPTION
User Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0.3 Safari/605.1.15
Browser: Safari 14 (on Mac OS 10.15.6) 
Hash Digest: 5de2f9eeda
