### PR TITLE
Results from Safari 14.1 / Mac OS 10.15.7 / Collector v3.1.4

### DIFF
--- a/3.1.4-safari-14.1-mac-os-10.15.7-63bb2fc1fa.json
+++ b/3.1.4-safari-14.1-mac-os-10.15.7-63bb2fc1fa.json
@@ -1,0 +1,1 @@
+{"__version":"3.1.4","results":{"https://mdn-bcd-collector.appspot.com/tests/api/ExtendableEvent/waitUntil":[{"exposure":"ServiceWorker","name":"api.ExtendableEvent.waitUntil","result":true}]},"userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1 Safari/605.1.15"}


### PR DESCRIPTION
User Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1 Safari/605.1.15
Browser: Safari 14.1 (on Mac OS 10.15.7) 
Hash Digest: 63bb2fc1fa
