### PR TITLE
Results from Chrome Android 92 / Android 11 / Collector v3.2.11

### DIFF
--- a/3.2.11-chrome-android-92.0.4515.159-android-11-c8b1ab1836.json
+++ b/3.2.11-chrome-android-92.0.4515.159-android-11-c8b1ab1836.json
@@ -1,0 +1,1 @@
+{"__version":"3.2.11","results":{"http://mdn-bcd-collector.appspot.com/tests/api/RTCPeerConnection/RTCPeerConnection":[{"exposure":"Window","name":"api.RTCPeerConnection.RTCPeerConnection","result":true}]},"userAgent":"Mozilla/5.0 (Linux; Android 11; CPH2089) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Mobile Safari/537.36"}


### PR DESCRIPTION
User Agent: Mozilla/5.0 (Linux; Android 11; CPH2089) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Mobile Safari/537.36
Browser: Chrome Android 92 (on Android 11) 
Hash Digest: c8b1ab1836
