### PR TITLE
Results from Samsung Browser 15.0 / Linux x86_64 / Collector v3.2.11

### DIFF
--- a/3.2.11-samsunginternet-15.0-linux-x86_64-3f33968862.json
+++ b/3.2.11-samsunginternet-15.0-linux-x86_64-3f33968862.json
@@ -1,0 +1,1 @@
+{"__version":"3.2.11","results":{"http://mdn-bcd-collector.appspot.com/tests/api/CSSTransition/transitionProperty":[{"exposure":"Window","name":"api.CSSTransition.transitionProperty","result":true}]},"userAgent":"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/15.0 Chrome/90.0.4430.210 Safari/537.36"}


### PR DESCRIPTION
User Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/15.0 Chrome/90.0.4430.210 Safari/537.36
Browser: Samsung Browser 15.0 (on Linux x86_64)  - **Not in BCD**
Hash Digest: 3f33968862
