### PR TITLE
Results from Safari on iOS 14.5 / iOS 14.7.1 / Collector v3.2.12

### DIFF
--- a/3.2.12-safari-ios-14.7.1-ios-14.7.1-1aeda22265.json
+++ b/3.2.12-safari-ios-14.7.1-ios-14.7.1-1aeda22265.json
@@ -1,0 +1,1 @@
+{"__version":"3.2.12","results":{},"userAgent":"Mozilla/5.0 (iPhone; CPU iPhone OS 14_7_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.2 Mobile/15E148 Safari/604.1"}


### PR DESCRIPTION
User Agent: Mozilla/5.0 (iPhone; CPU iPhone OS 14_7_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.2 Mobile/15E148 Safari/604.1
Browser: Safari on iOS 14.5 (on iOS 14.7.1) 
Hash Digest: 1aeda22265
