### PR TITLE
Results from Chrome 89 / Linux x86_64 / Collector v4.0.0

### DIFF
--- a/4.0.0-chrome-89.0.4389.72-linux-x86_64-c2c9d9f4ff.json
+++ b/4.0.0-chrome-89.0.4389.72-linux-x86_64-c2c9d9f4ff.json
@@ -1,0 +1,1 @@
+{"__version":"4.0.0","results":{},"userAgent":"Mozilla/5.0 (X11; Linux x86_64; GoogleSecurityScanner) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.72 Safari/537.36 (scan 5052440443371520, run 6193518764638208) TO STOP THIS SECURITY SCAN go/scan"}


### PR DESCRIPTION
User Agent: Mozilla/5.0 (X11; Linux x86_64; GoogleSecurityScanner) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.72 Safari/537.36 (scan 5052440443371520, run 6193518764638208) TO STOP THIS SECURITY SCAN go/scan
Browser: Chrome 89 (on Linux x86_64) 
Hash Digest: c2c9d9f4ff
