### PR TITLE
Results from Safari 15 / Mac OS 10.15.7 / Collector v6.0.5

### DIFF
--- a/6.0.5-safari-15.0-mac-os-10.15.7-c2ea9a5864.json
+++ b/6.0.5-safari-15.0-mac-os-10.15.7-c2ea9a5864.json
@@ -1,0 +1,1 @@
+{"__version":"6.0.5","results":{"https://mdn-bcd-collector.appspot.com/tests/api/BluetoothAdvertisingEvent/BluetoothAdvertisingEvent":[{"exposure":"Window","name":"api.BluetoothAdvertisingEvent.BluetoothAdvertisingEvent","result":false}]},"userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 Safari/605.1.15"}


### PR DESCRIPTION
User Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 Safari/605.1.15
Browser: Safari 15 (on Mac OS 10.15.7)
Hash Digest: c2ea9a5864
Test URLs: https://mdn-bcd-collector.appspot.com/tests/api/BluetoothAdvertisingEvent/BluetoothAdvertisingEvent