### PR TITLE
Results from Chrome 103 / Mac OS 10.15.7 / Collector v6.0.9

### DIFF
--- a/6.0.9-chrome-103.0.0.0-mac-os-10.15.7-937915f4e3.json
+++ b/6.0.9-chrome-103.0.0.0-mac-os-10.15.7-937915f4e3.json
@@ -1,0 +1,1 @@
+{"__version":"6.0.9","results":{"https://mdn-bcd-collector.appspot.com/tests/api/VideoFrame/copyTo":[{"exposure":"Window","name":"api.VideoFrame.copyTo","result":true},{"exposure":"Worker","name":"api.VideoFrame.copyTo","result":true}]},"userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.0.0 Safari/537.36"}


### PR DESCRIPTION
User Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.0.0 Safari/537.36
Browser: Chrome 103 (on Mac OS 10.15.7)
Hash Digest: 937915f4e3
Test URLs: https://mdn-bcd-collector.appspot.com/tests/api/VideoFrame/copyTo