### PR TITLE
Results from Edge iOS 15.6 / iOS 15.6 / Collector v6.1.4

### DIFF
--- a/6.1.4-edge-ios-15.6-ios-15.6-79177c8614.json
+++ b/6.1.4-edge-ios-15.6-ios-15.6-79177c8614.json
@@ -1,0 +1,1 @@
+{"__version":"6.1.4","results":{"https://mdn-bcd-collector.appspot.com/tests/api/Sanitizer/getConfiguration":[{"exposure":"Window","name":"api.Sanitizer.getConfiguration","result":false}]},"userAgent":"Mozilla/5.0 (iPhone; CPU iPhone OS 15_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) EdgiOS/104.0.1293.70 Version/15.0 Mobile/15E148 Safari/604.1"}


### PR DESCRIPTION
User Agent: Mozilla/5.0 (iPhone; CPU iPhone OS 15_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) EdgiOS/104.0.1293.70 Version/15.0 Mobile/15E148 Safari/604.1
Browser: Edge iOS 15.6 (on iOS 15.6) - **Not in BCD**
Hash Digest: 79177c8614
Test URLs: https://mdn-bcd-collector.appspot.com/tests/api/Sanitizer/getConfiguration