### PR TITLE
Results from Edge iOS 15.6 / iOS 15.6 / Collector v6.2.2

### DIFF
--- a/6.2.2-edge-ios-15.6-ios-15.6-af4bdab494.json
+++ b/6.2.2-edge-ios-15.6-ios-15.6-af4bdab494.json
@@ -1,0 +1,1 @@
+{"__version":"6.2.2","results":{},"userAgent":"Mozilla/5.0 (iPhone; CPU iPhone OS 15_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) EdgiOS/104.0.1293.70 Version/15.0 Mobile/15E148 Safari/604.1"}


### PR DESCRIPTION
User Agent: Mozilla/5.0 (iPhone; CPU iPhone OS 15_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) EdgiOS/104.0.1293.70 Version/15.0 Mobile/15E148 Safari/604.1
Browser: Edge iOS 15.6 (on iOS 15.6) - **Not in BCD**
Hash Digest: af4bdab494
Test URLs: 