### PR TITLE
Results from Firefox 109 / Mac OS 10.15 / Collector v6.2.8

### DIFF
--- a/6.2.8-firefox-109.0-mac-os-10.15-eca57d5b90.json
+++ b/6.2.8-firefox-109.0-mac-os-10.15-eca57d5b90.json
@@ -1,0 +1,1 @@
+{"__version":"6.2.8","results":{"https://mdn-bcd-collector.appspot.com/tests/css/properties/container":[{"exposure":"Window","name":"css.properties.container","result":true}]},"userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:109.0) Gecko/20100101 Firefox/109.0"}


### PR DESCRIPTION
User Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:109.0) Gecko/20100101 Firefox/109.0
Browser: Firefox 109 (on Mac OS 10.15)
Hash Digest: eca57d5b90
Test URLs: https://mdn-bcd-collector.appspot.com/tests/css/properties/container