### PR TITLE
Results from Chrome 120.0 / Mac OS 10.15.7 / Collector v6.2.11

### DIFF
--- a/6.2.11-chrome-120.0.0.0-mac-os-10.15.7-1cec29a6e1.json
+++ b/6.2.11-chrome-120.0.0.0-mac-os-10.15.7-1cec29a6e1.json
@@ -1,0 +1,1 @@
+{"__version":"6.2.11","results":{"https://mdn-bcd-collector.appspot.com/tests/api/OTPCredential":[{"exposure":"Window","name":"api.OTPCredential.code","result":true},{"exposure":"Window","name":"api.OTPCredential","result":true}]},"userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"}


### PR DESCRIPTION
User Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36
Browser: Chrome 120.0 (on Mac OS 10.15.7) - **Not in BCD**
Hash Digest: 1cec29a6e1
Test URLs: https://mdn-bcd-collector.appspot.com/tests/api/OTPCredential